### PR TITLE
#10: Antonio: Implemented a way to make moving pictures within their …

### DIFF
--- a/photocollage/collage.py
+++ b/photocollage/collage.py
@@ -83,10 +83,25 @@ class Photo(object):
         self.w = w
         self.h = h
         self.orientation = orientation
+        self.offset_w = 0.5
+        self.offset_h = 0.5
 
     @property
     def ratio(self):
         return float(self.h) / float(self.w)
+
+    def move(self, x, y):
+        self.offset_w = self.calculate_new_offset(self.offset_w, x)
+        self.offset_h = self.calculate_new_offset(self.offset_h, y)
+
+    @staticmethod
+    def calculate_new_offset(offset, value):
+        new_offset = offset + value
+        if new_offset < 0:
+            new_offset = 0
+        elif new_offset > 1:
+            new_offset = 1
+        return new_offset
 
 
 class Cell(object):

--- a/photocollage/render.py
+++ b/photocollage/render.py
@@ -235,13 +235,23 @@ class RenderingTask(Thread):
             cache[cell.photo.filename] = img
 
         if shape > 0:  # image is too thick
-            img = img.crop(
-                (int(round((img.size[0] - cell.w) / 2)), 0,
-                 int(round((img.size[0] + cell.w) / 2)), int(round(cell.h))))
+            width_to_crop = img.size[0] - cell.w
+            img = img.crop((
+                int(round(width_to_crop * cell.photo.offset_w)),
+                0,
+                int(round(img.size[0] - width_to_crop *
+                    (1 - cell.photo.offset_w))),
+                int(round(cell.h))
+            ))
         elif shape < 0:  # image is too tall
-            img = img.crop(
-                (0, int(round((img.size[1] - cell.h) / 2)),
-                 int(round(cell.w)), int(round((img.size[1] + cell.h) / 2))))
+            height_to_crop = img.size[1] - cell.h
+            img = img.crop((
+                0,
+                int(round(height_to_crop * cell.photo.offset_h)),
+                int(round(cell.w)),
+                int(round(img.size[1] - height_to_crop *
+                    (1 - cell.photo.offset_h)))
+            ))
 
         return img
 


### PR DESCRIPTION
Hi Adrien,

I realised that the functionality #10 has already been implemented just after I did it myself.
My solution is very similar to the one provided by jdavidberger, with the difference that there's no need to press the CTRL button to move the image.

For more info see the description below.

Any reason why the other pull request wasn't merged yet?
Furthermore how long usually take for the update of the apt repository?

Kind regards
Antonio


Commmit Comment:
The Photo object has been updated with two extra properties: offset_w and offset_h which represent respectively the offset on the width and the offset on the height of a photo within their frame.
The offset value must be a number between 0 and 1:
  - 0: means the photo is not cut on the left (top) but is fully cut on the right (bottom)
  - 1: means the photo is not cut on the right (bottom) but is fully cut on the left
  - 0.5: is the default value and means the photo is centered
  - any other value betwen 0 and 1 will move the photo within the frame
  A public move method has been added to move the photo within the cell.

  ImagePreviewArea.SWAPPING has been renamed as SWAPPING_OR_MOVING because when clicking, moving the mouse and realising will trigger two different actions:
    - SWAPPING: if the release of the button is done on another cell
    - MOVING: if the release of the button is done on the same cell
 The method ImagePreviewArea.button_release_event() has been accordingly modified.

 The method RenderingTask.resize_photo() has been modified to take the offset in account.