### PR TITLE
Feature #38 add config file

### DIFF
--- a/photocollage/config.py
+++ b/photocollage/config.py
@@ -16,7 +16,29 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+# import
+import logging
+import os
+import time
 import yaml
+
+
+# constant definition
+FILE_OPEN_TIME_STEP = 0.32414  #: some random value between opening trials
+FILE_OPEN_TIMEOUT = 2  #: in seconds
+
+# logging configuration
+logging.basicConfig(level=logging.DEBUG)
+top_logger = logging.getLogger(__name__)
+
+
+# classes definition
+class ConfigLoadError(IOError):
+    pass
+
+
+class ConfigStoreError(IOError):
+    pass
 
 
 class YamlConfig(object):
@@ -24,7 +46,6 @@ class YamlConfig(object):
 
     Takes care of writing configuration to filesystem at exit.
 
-    >>> import os
     >>> cfg_fn = "../tests/cfg.yml"
     >>> if os.path.exists(cfg_fn):
     ...     os.remove(cfg_fn)
@@ -38,24 +59,65 @@ class YamlConfig(object):
     configuration: {last_visited_directory: /home/adrien/photos}
     <BLANKLINE>
 
+    >>> cfg2 = YamlConfig(cfg_fn)
+    >>> cfg2.load()
+    >>> print(cfg2)
+    <YamlConfig object: {'configuration': {'last_visited_directory': '/home/adrien/photos'}}>
+
     """
     def __init__(self, cfg_fn, *args, **kwargs):
+        self.logger = top_logger.getChild(__name__)
         self._data = dict(*args, **kwargs)
         self.cfg_fn = cfg_fn
-        self.load()
 
     def load(self):
+        """Load content of *self.cfg_fn*, as a YAML file, in instance.
+
+        """
         self._data.clear()
-        if self.cfg_fn is not None:
+        if self.cfg_fn is not None and os.path.exists(self.cfg_fn):
             try:
-                with open(self.cfg_fn, 'r') as fin:
+                with open_(self.cfg_fn, 'r') as fin:
                     self._data.update(yaml.load(fin))
-            except (IOError, OSError):
-                pass
+            except (IOError, OSError) as e:
+                raise ConfigLoadError("Could not load config file: {}"
+                                      .format(e))
+        else:
+            raise ConfigLoadError("Could not load config: no cfg_fn "
+                                  "provided")
 
     def store(self):
-        with open(self.cfg_fn, 'w') as fout:
-            fout.write(yaml.dump(self._data))
+        """Write instance content to *self.cfg_fn*, as YAML file.
+
+        """
+        if self.cfg_fn is not None:
+            dir_ = os.path.dirname(self.cfg_fn)
+            if os.path.exists(self.cfg_fn):
+                if os.path.isdir(self.cfg_fn):
+                    raise ConfigStoreError("Cannot store, as cfg_fn is a "
+                                           "directory : '{}'"
+                                           .format(self.cfg_fn))
+                else:
+                    # file exists and will be overwritten: no action
+                    pass
+            elif os.path.exists(dir_):
+                if os.path.isfile(dir_):
+                    raise ConfigStoreError("Cannot store, as cfg_fn "
+                                           "directory exists as a file: "
+                                           "'{}'"
+                                           .format(self.cfg_fn))
+                else:
+                    # cfg_fn directory exists: no action
+                    pass
+            else:
+                # create directory for storing the file
+                os.makedirs(dir_)
+
+            with open_(self.cfg_fn, 'w') as fout:
+                fout.write(yaml.dump(self._data))
+        else:
+            raise ConfigStoreError("Could not store config: no cfg_fn "
+                                   "provided")
 
     def __getitem__(self, item):
         return self._data[item]
@@ -66,6 +128,43 @@ class YamlConfig(object):
     def __repr__(self):
         return "<{0} object: {1}>".format(self.__class__.__name__,
                                           self._data)
+
+
+def open_(fn, *args, **kwargs):
+    """Wraps around built-in :py:func:open function, that waits for the
+    resource to become free.
+
+    *ars* and *kwargs* are passed to built-in :py:func:open function.
+
+    ..Note:
+        Some keyword arguments are reserved:
+
+        * Parameter *timeout_* is used to set a maximum waiting time (in
+          seconds). Deactivated if value is 0, default value is
+          :py:const:FILE_OPEN_TIMEOUT.
+        * Parameter *_top* is used for control of warning display to user.
+
+    """
+    logger = top_logger.getChild("open_")
+    timeout_ = kwargs.pop("timeout_", FILE_OPEN_TIMEOUT)
+    _top = kwargs.pop("_top", True)  # True by default
+    if timeout_ < 0:
+        raise IOError("Could not open file within timeout: {}"
+                      .format(fn))
+    try:
+        fh = open(fn, *args, **kwargs)
+    except IOError as e:
+        if _top:  # if call from user, show a warning
+            logger.warning("File not available: '{}', waiting for it to be"
+                           " freed: {}"
+                           .format(os.path.basename(fn), e))
+        time.sleep(FILE_OPEN_TIME_STEP)  # then wait a little
+        kwargs["timeout_"] = timeout_ - FILE_OPEN_TIME_STEP if timeout_ > 0 else 0
+        kwargs["_top"] = False  # force _top at False for new try
+        return open_(fn, *args, **kwargs)   # and make a new try
+    else:
+        logger.debug("File '{}' opened".format(os.path.basename(fn)))
+        return fh
 
 
 if __name__ == '__main__':

--- a/photocollage/config.py
+++ b/photocollage/config.py
@@ -129,6 +129,31 @@ class YamlConfig(object):
         return "<{0} object: {1}>".format(self.__class__.__name__,
                                           self._data)
 
+    def setdefault(self, **kwargs):
+        """Set values if not already existing
+
+        >>> cfg = YamlConfig(None)
+        >>> cfg['a'] = 1
+        >>> cfg.setdefault(a=0, b=2, c=3)
+        >>> cfg
+        <YamlConfig object: {'a': 1, 'b': 2, 'c': 3}>
+
+        """
+        for k, v in kwargs.items():
+            self._data.setdefault(k, v)
+
+    def update(self, **kwargs):
+        """Update or set values
+
+        >>> cfg = YamlConfig(None)
+        >>> cfg['a'] = 1
+        >>> cfg.update(a=0, b=2, c=3)
+        >>> cfg
+        <YamlConfig object: {'a': 0, 'b': 2, 'c': 3}>
+
+        """
+        self._data.update(kwargs)
+
 
 def open_(fn, *args, **kwargs):
     """Wraps around built-in :py:func:open function, that waits for the

--- a/photocollage/config.py
+++ b/photocollage/config.py
@@ -33,91 +33,91 @@ top_logger = logging.getLogger(__name__)
 
 
 # classes definition
-class ConfigLoadError(IOError):
+class OptionsLoadError(IOError):
     pass
 
 
-class ConfigStoreError(IOError):
+class OptionsStoreError(IOError):
     pass
 
 
-class YamlConfig(object):
-    """Handles configuration, based on a YAML file.
+class YamlOptionsManager(object):
+    """Handles options, based on a YAML file.
 
     Takes care of writing configuration to filesystem at exit.
 
-    >>> cfg_fn = "../tests/cfg.yml"
-    >>> if os.path.exists(cfg_fn):
-    ...     os.remove(cfg_fn)
+    >>> opts_fn = "../tests/opts.yml"
+    >>> if os.path.exists(opts_fn):
+    ...     os.remove(opts_fn)
     ...
-    >>> cfg = YamlConfig(cfg_fn)
-    >>> print(cfg)
-    <YamlConfig object: {}>
-    >>> cfg['configuration'] = dict(last_visited_directory="/home/adrien/photos")
-    >>> cfg.store()
-    >>> print(open(cfg_fn).read())
+    >>> opts = YamlOptionsManager(opts_fn)
+    >>> print(opts)
+    <YamlOptionsManager object: {}>
+    >>> opts['configuration'] = dict(last_visited_directory="/home/adrien/photos")
+    >>> opts.store()
+    >>> print(open(opts_fn).read())
     configuration: {last_visited_directory: /home/adrien/photos}
     <BLANKLINE>
 
-    >>> cfg2 = YamlConfig(cfg_fn)
+    >>> cfg2 = YamlOptionsManager(opts_fn)
     >>> cfg2.load()
     >>> print(cfg2)
-    <YamlConfig object: {'configuration': {'last_visited_directory': '/home/adrien/photos'}}>
+    <YamlOptionsManager object: {'configuration': {'last_visited_directory': '/home/adrien/photos'}}>
 
     """
-    def __init__(self, cfg_fn, *args, **kwargs):
+    def __init__(self, opts_fn, *args, **kwargs):
         self.logger = top_logger.getChild(__name__)
         self._data = dict(*args, **kwargs)
-        self.cfg_fn = cfg_fn
+        self.opts_fn = opts_fn
 
     def load(self):
-        """Load content of *self.cfg_fn*, as a YAML file, in instance.
+        """Load content of *self.opts_fn*, as a YAML file, in instance.
 
         """
         self._data.clear()
-        if self.cfg_fn is not None and os.path.exists(self.cfg_fn):
+        if self.opts_fn is not None and os.path.exists(self.opts_fn):
             try:
-                with open_(self.cfg_fn, 'r') as fin:
+                with open_(self.opts_fn, 'r') as fin:
                     self._data.update(yaml.load(fin))
             except (IOError, OSError) as e:
-                raise ConfigLoadError("Could not load config file: {}"
-                                      .format(e))
+                raise OptionsLoadError("Could not load options file: {}"
+                                       .format(e))
         else:
-            raise ConfigLoadError("Could not load config: no cfg_fn "
+            raise OptionsLoadError("Could not load options: no opts_fn "
                                   "provided")
 
     def store(self):
-        """Write instance content to *self.cfg_fn*, as YAML file.
+        """Write instance content to *self.opts_fn*, as YAML file.
 
         """
-        if self.cfg_fn is not None:
-            dir_ = os.path.dirname(self.cfg_fn)
-            if os.path.exists(self.cfg_fn):
-                if os.path.isdir(self.cfg_fn):
-                    raise ConfigStoreError("Cannot store, as cfg_fn is a "
-                                           "directory : '{}'"
-                                           .format(self.cfg_fn))
+        if self.opts_fn is not None:
+            dir_ = os.path.dirname(self.opts_fn)
+            if os.path.exists(self.opts_fn):
+                if os.path.isdir(self.opts_fn):
+                    raise OptionsStoreError(
+                        "Cannot store, as opts_fn is a directory : '{}'"
+                        .format(self.opts_fn))
                 else:
                     # file exists and will be overwritten: no action
                     pass
             elif os.path.exists(dir_):
                 if os.path.isfile(dir_):
-                    raise ConfigStoreError("Cannot store, as cfg_fn "
-                                           "directory exists as a file: "
-                                           "'{}'"
-                                           .format(self.cfg_fn))
+                    raise OptionsStoreError(
+                        "Cannot store, as opts_fn directory exists as a "
+                        "file: '{}'"
+                        .format(self.opts_fn))
                 else:
-                    # cfg_fn directory exists: no action
+                    # opts_fn directory exists: no action
                     pass
             else:
                 # create directory for storing the file
                 os.makedirs(dir_)
 
-            with open_(self.cfg_fn, 'w') as fout:
+            with open_(self.opts_fn, 'w') as fout:
                 fout.write(yaml.dump(self._data))
         else:
-            raise ConfigStoreError("Could not store config: no cfg_fn "
-                                   "provided")
+            raise OptionsStoreError("Could not store config: no opts_fn "
+                                    "provided")
 
     def __getitem__(self, item):
         return self._data[item]
@@ -132,11 +132,11 @@ class YamlConfig(object):
     def setdefault(self, **kwargs):
         """Set values if not already existing
 
-        >>> cfg = YamlConfig(None)
-        >>> cfg['a'] = 1
-        >>> cfg.setdefault(a=0, b=2, c=3)
-        >>> cfg
-        <YamlConfig object: {'a': 1, 'b': 2, 'c': 3}>
+        >>> opts = YamlOptionsManager(None)
+        >>> opts['a'] = 1
+        >>> opts.setdefault(a=0, b=2, c=3)
+        >>> opts
+        <YamlOptionsManager object: {'a': 1, 'b': 2, 'c': 3}>
 
         """
         for k, v in kwargs.items():
@@ -145,11 +145,11 @@ class YamlConfig(object):
     def update(self, **kwargs):
         """Update or set values
 
-        >>> cfg = YamlConfig(None)
-        >>> cfg['a'] = 1
-        >>> cfg.update(a=0, b=2, c=3)
-        >>> cfg
-        <YamlConfig object: {'a': 0, 'b': 2, 'c': 3}>
+        >>> opts = YamlOptionsManager(None)
+        >>> opts['a'] = 1
+        >>> opts.update(a=0, b=2, c=3)
+        >>> opts
+        <YamlOptionsManager object: {'a': 0, 'b': 2, 'c': 3}>
 
         """
         self._data.update(kwargs)

--- a/photocollage/config.py
+++ b/photocollage/config.py
@@ -84,7 +84,7 @@ class YamlOptionsManager(object):
                                        .format(e))
         else:
             raise OptionsLoadError("Could not load options: no opts_fn "
-                                  "provided")
+                                   "provided")
 
     def store(self):
         """Write instance content to *self.opts_fn*, as YAML file.
@@ -184,9 +184,11 @@ def open_(fn, *args, **kwargs):
                            " freed: {}"
                            .format(os.path.basename(fn), e))
         time.sleep(FILE_OPEN_TIME_STEP)  # then wait a little
-        kwargs["timeout_"] = timeout_ - FILE_OPEN_TIME_STEP if timeout_ > 0 else 0
-        kwargs["_top"] = False  # force _top at False for new try
-        return open_(fn, *args, **kwargs)   # and make a new try
+        # update parameters for next trial
+        kwargs["timeout_"] = (timeout_ - FILE_OPEN_TIME_STEP
+                              if timeout_ > 0 else 0)
+        kwargs["_top"] = False
+        return open_(fn, *args, **kwargs) 
     else:
         logger.debug("File '{}' opened".format(os.path.basename(fn)))
         return fh

--- a/photocollage/config.py
+++ b/photocollage/config.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017 Joël BOURGAULT
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+import yaml
+
+
+class YamlConfig(object):
+    """Handles configuration, based on a YAML file.
+
+    Takes care of writing configuration to filesystem at exit.
+
+    >>> import os
+    >>> cfg_fn = "../tests/cfg.yml"
+    >>> if os.path.exists(cfg_fn):
+    ...     os.remove(cfg_fn)
+    ...
+    >>> cfg = YamlConfig(cfg_fn)
+    >>> print(cfg)
+    <YamlConfig object: {}>
+    >>> cfg['configuration'] = dict(last_visited_directory="/home/adrien/photos")
+    >>> cfg.store()
+    >>> print(open(cfg_fn).read())
+    configuration: {last_visited_directory: /home/adrien/photos}
+    <BLANKLINE>
+
+    """
+    def __init__(self, cfg_fn, *args, **kwargs):
+        self._data = dict(*args, **kwargs)
+        self.cfg_fn = cfg_fn
+        self.load()
+
+    def load(self):
+        self._data.clear()
+        if self.cfg_fn is not None:
+            try:
+                with open(self.cfg_fn, 'r') as fin:
+                    self._data.update(yaml.load(fin))
+            except (IOError, OSError):
+                pass
+
+    def store(self):
+        with open(self.cfg_fn, 'w') as fout:
+            fout.write(yaml.dump(self._data))
+
+    def __getitem__(self, item):
+        return self._data[item]
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+    def __repr__(self):
+        return "<{0} object: {1}>".format(self.__class__.__name__,
+                                          self._data)
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/photocollage/config.py
+++ b/photocollage/config.py
@@ -30,7 +30,6 @@ FILE_OPEN_TIME_STEP = 0.32414  #: some random value between opening trials
 FILE_OPEN_TIMEOUT = 2  #: in seconds
 
 # logging configuration
-logging.basicConfig(level=logging.DEBUG)
 top_logger = logging.getLogger(__name__)
 
 gettext.textdomain(APP_NAME)
@@ -109,8 +108,8 @@ class OptionsManager(object):
         self._data.update(kwargs)
 
     def __repr__(self):
-        return "<{0} object: {1}>".format(self.__class__.__name__,
-                                          self._data)
+        return "<%s object: %s>" % (self.__class__.__name__,
+                                    self._data)
 
 
 class YamlOptionsManager(OptionsManager):
@@ -166,26 +165,28 @@ class YamlOptionsManager(OptionsManager):
             self._logger.debug(_("Storing config to filesystem: '%s'")
                                % self.opts_fn)
             dir_ = os.path.dirname(self.opts_fn)
-            if os.path.exists(self.opts_fn):
-                if os.path.isdir(self.opts_fn):
-                    raise OptionsStoreError(
-                        _("Cannot store, as opts_fn is a directory : '%s'")
-                        % self.opts_fn)
+            if dir_:  # no need to investigate if dir_ is ''
+                if os.path.exists(self.opts_fn):
+                    if os.path.isdir(self.opts_fn):
+                        raise OptionsStoreError(
+                            _("Cannot store, as opts_fn is a directory : "
+                              "'%s'")
+                            % self.opts_fn)
+                    else:
+                        # file exists and will be overwritten: no action
+                        pass
+                elif os.path.exists(dir_):
+                    if os.path.isfile(dir_):
+                        raise OptionsStoreError(
+                            _("Cannot store, as opts_fn directory exists "
+                              "as a file: '%s'")
+                            % self.opts_fn)
+                    else:
+                        # opts_fn directory exists: no action
+                        pass
                 else:
-                    # file exists and will be overwritten: no action
-                    pass
-            elif os.path.exists(dir_):
-                if os.path.isfile(dir_):
-                    raise OptionsStoreError(
-                        _("Cannot store, as opts_fn directory exists as a "
-                          "file: '%s'")
-                        % self.opts_fn)
-                else:
-                    # opts_fn directory exists: no action
-                    pass
-            else:
-                # create directory for storing the file
-                os.makedirs(dir_)
+                    # create directory for storing the file
+                    os.makedirs(dir_)
 
             with open_(self.opts_fn, 'w') as fout:
                 fout.write(yaml.dump(self._data))

--- a/photocollage/config.py
+++ b/photocollage/config.py
@@ -119,7 +119,7 @@ class YamlOptionsManager(OptionsManager):
     >>> opts = YamlOptionsManager(opts_fn)
     >>> print(opts)
     <YamlOptionsManager object: {}>
-    >>> opts['configuration'] = dict(last_visited_directory="/home/adrien/photos")
+    >>> opts.configuration = dict(last_visited_directory="/home/adrien/photos")
     >>> opts.store()
     >>> print(open(opts_fn).read())
     configuration: {last_visited_directory: /home/adrien/photos}
@@ -127,8 +127,8 @@ class YamlOptionsManager(OptionsManager):
 
     >>> cfg2 = YamlOptionsManager(opts_fn)
     >>> cfg2.load()
-    >>> print(cfg2)
-    <YamlOptionsManager object: {'configuration': {'last_visited_directory': '/home/adrien/photos'}}>
+    >>> cfg2.configuration
+    {'last_visited_directory': '/home/adrien/photos'}
 
     """
     def __init__(self, opts_fn, *args, **kwargs):

--- a/photocollage/config.py
+++ b/photocollage/config.py
@@ -75,13 +75,13 @@ class OptionsManager(object):
         if not item.startswith('_') and item not in self._PROTECTED_NAMES:
             return self._data[item]
         else:
-            return super().__getattribute__(item)
+            return super(OptionsManager, self).__getattribute__(item)
 
     def __setattr__(self, key, value):
         if not key.startswith('_') and key not in self._PROTECTED_NAMES:
             self._data[key] = value
         else:
-            super().__setattr__(key, value)
+            super(OptionsManager, self).__setattr__(key, value)
 
     def setdefault(self, **kwargs):
         """Set values if not already existing
@@ -138,7 +138,7 @@ class YamlOptionsManager(OptionsManager):
 
     """
     def __init__(self, opts_fn, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(YamlOptionsManager, self).__init__(*args, **kwargs)
         self._PROTECTED_NAMES += ('load', 'store', 'opts_fn')
         self.opts_fn = opts_fn
 

--- a/photocollage/gtkgui.py
+++ b/photocollage/gtkgui.py
@@ -31,7 +31,7 @@ from six.moves import urllib  # Python 2 backward compatibility
 
 from photocollage import APP_NAME, artwork, collage, render
 from photocollage.render import PIL_SUPPORTED_EXTS as EXTS
-from photocollage.config import YamlConfig
+from photocollage.config import YamlConfig, ConfigStoreError, ConfigLoadError
 
 gettext.textdomain(APP_NAME)
 _ = gettext.gettext
@@ -170,6 +170,11 @@ class PhotoCollageWindow(Gtk.Window):
         self.history_index = 0
 
         self.cfg = config
+        # load if config file exists
+        try:
+            self.cfg.load()
+        except ConfigLoadError:
+            pass
 
         class Options(object):
             def __init__(self):

--- a/photocollage/gtkgui.py
+++ b/photocollage/gtkgui.py
@@ -176,8 +176,9 @@ class PhotoCollageWindow(Gtk.Window):
         except OptionsLoadError:
             pass
         # set default values
+        # TODO: put this in a default location, or in a default option file
         self.opts.setdefault(border_w=0.01, border_c='black',
-                            out_w=800, out_h=600)
+                             out_w=800, out_h=600)
 
         self.make_window()
 
@@ -278,8 +279,8 @@ class PhotoCollageWindow(Gtk.Window):
 
             if len(photolist) > 0:
                 new_collage = UserCollage(photolist)
-                new_collage.make_page(out_h=self.opts['out_h'],
-                                      out_w=self.opts['out_w'])
+                new_collage.make_page(out_h=self.opts.out_h,
+                                      out_w=self.opts.out_w)
                 self.render_from_new_collage(new_collage)
             else:
                 self.update_tool_buttons()
@@ -321,7 +322,7 @@ class PhotoCollageWindow(Gtk.Window):
 
         # If the desired ratio changed in the meantime (e.g. from landscape to
         # portrait), it needs to be re-updated
-        collage.page.target_ratio = 1.0 * self.opts['out_h'] / self.opts['out_w']
+        collage.page.target_ratio = 1.0 * self.opts.out_h / self.opts.out_w
         collage.page.adjust_cols_heights()
 
         w = self.img_preview.get_allocation().width
@@ -350,9 +351,9 @@ class PhotoCollageWindow(Gtk.Window):
 
         t = render.RenderingTask(
             collage.page,
-            border_width=self.opts['border_w'] * max(collage.page.w,
-                                                    collage.page.h),
-            border_color=self.opts['border_c'],
+            border_width=self.opts.border_w * max(collage.page.w,
+                                                  collage.page.h),
+            border_color=self.opts.border_c,
             on_update=gtk_run_in_main_thread(on_update),
             on_complete=gtk_run_in_main_thread(on_complete),
             on_fail=gtk_run_in_main_thread(on_fail))
@@ -371,8 +372,8 @@ class PhotoCollageWindow(Gtk.Window):
 
     def regenerate_layout(self, button=None):
         new_collage = self.history[self.history_index].duplicate()
-        new_collage.make_page(out_h=self.opts['out_h'],
-                              out_w=self.opts['out_w'])
+        new_collage.make_page(out_h=self.opts.out_h,
+                              out_w=self.opts.out_w)
         self.render_from_new_collage(new_collage)
 
     def select_prev_layout(self, button):
@@ -399,7 +400,7 @@ class PhotoCollageWindow(Gtk.Window):
     def save_poster(self, button):
         collage = self.history[self.history_index]
 
-        enlargement = float(self.opts['out_w']) / collage.page.w
+        enlargement = float(self.opts.out_w) / collage.page.w
         collage.page.scale(enlargement)
 
         dialog = Gtk.FileChooserDialog(_("Save image"), button.get_toplevel(),
@@ -435,9 +436,9 @@ class PhotoCollageWindow(Gtk.Window):
 
         t = render.RenderingTask(
             collage.page, output_file=savefile,
-            border_width=self.opts['border_w'] * max(collage.page.w,
-                                                    collage.page.h),
-            border_color=self.opts['border_c'],
+            border_width=self.opts.border_w * max(collage.page.w,
+                                                  collage.page.h),
+            border_color=self.opts.border_c,
             on_update=gtk_run_in_main_thread(on_update),
             on_complete=gtk_run_in_main_thread(on_complete),
             on_fail=gtk_run_in_main_thread(on_fail))
@@ -599,8 +600,8 @@ class ImagePreviewArea(Gtk.DrawingArea):
             if dist <= 8 * 8:
                 self.collage.photolist.remove(cell.photo)
                 if self.collage.photolist:
-                    self.collage.make_page(out_h=self.parent.opts['out_h'],
-                                           out_w=self.parent.opts['out_w'])
+                    self.collage.make_page(out_h=self.parent.opts.out_h,
+                                           out_w=self.parent.opts.out_w)
                     self.parent.render_from_new_collage(self.collage)
                 else:
                     self.image = None
@@ -644,7 +645,7 @@ class SettingsDialog(Gtk.Dialog):
              Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL))
         self.set_border_width(10)
 
-        self.selected_border_color = parent.opts['border_c']
+        self.selected_border_color = parent.opts.border_c
 
         box = self.get_content_area()
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
@@ -656,12 +657,12 @@ class SettingsDialog(Gtk.Dialog):
 
         box = Gtk.Box(spacing=6)
         vbox.pack_start(box, False, False, 0)
-        self.etr_outw = Gtk.Entry(text=str(parent.opts['out_w']))
+        self.etr_outw = Gtk.Entry(text=str(parent.opts.out_w))
         self.etr_outw.connect("changed", self.validate_int)
         self.etr_outw.last_valid_text = self.etr_outw.get_text()
         box.pack_start(self.etr_outw, False, False, 0)
         box.pack_start(Gtk.Label("×", xalign=0), False, False, 0)
-        self.etr_outh = Gtk.Entry(text=str(parent.opts['out_h']))
+        self.etr_outh = Gtk.Entry(text=str(parent.opts.out_h))
         self.etr_outh.connect("changed", self.validate_int)
         self.etr_outh.last_valid_text = self.etr_outh.get_text()
         box.pack_start(self.etr_outh, False, False, 0)
@@ -710,7 +711,7 @@ class SettingsDialog(Gtk.Dialog):
         vbox.pack_start(box, False, False, 0)
         label = Gtk.Label(_("Thickness:"), xalign=0)
         box.pack_start(label, False, False, 0)
-        self.etr_border = Gtk.Entry(text=str(100.0 * parent.opts['border_w']))
+        self.etr_border = Gtk.Entry(text=str(100.0 * parent.opts.border_w))
         self.etr_border.connect("changed", self.validate_float)
         self.etr_border.last_valid_text = self.etr_border.get_text()
         self.etr_border.set_width_chars(4)
@@ -723,7 +724,7 @@ class SettingsDialog(Gtk.Dialog):
         box.pack_start(label, True, True, 0)
         self.colorbutton = Gtk.ColorButton()
         color = Gdk.RGBA()
-        color.parse(parent.opts['border_c'])
+        color.parse(parent.opts.border_c)
         self.colorbutton.set_rgba(color)
         box.pack_end(self.colorbutton, False, False, 0)
 

--- a/photocollage/gtkgui.py
+++ b/photocollage/gtkgui.py
@@ -31,7 +31,7 @@ from six.moves import urllib  # Python 2 backward compatibility
 
 from photocollage import APP_NAME, artwork, collage, render
 from photocollage.render import PIL_SUPPORTED_EXTS as EXTS
-from photocollage.config import YamlConfig, ConfigStoreError, ConfigLoadError
+from photocollage.config import YamlOptionsManager, OptionsLoadError
 
 gettext.textdomain(APP_NAME)
 _ = gettext.gettext
@@ -157,10 +157,10 @@ class PhotoCollageWindow(Gtk.Window):
     TARGET_TYPE_TEXT = 1
     TARGET_TYPE_URI = 2
 
-    def __init__(self, config):
+    def __init__(self, options_manager):
         """
 
-        :param config: dict-like storage for configuration data. Shall also
+        :param options_manager: dict-like storage for configuration data. Shall also
             accept function `store`, that takes care of data persistence at
             exit.
 
@@ -169,11 +169,11 @@ class PhotoCollageWindow(Gtk.Window):
         self.history = []
         self.history_index = 0
 
-        self.opts = config
-        # load if config file exists
+        self.opts = options_manager
+        # load if options_manager file exists
         try:
             self.opts.load()
-        except ConfigLoadError:
+        except OptionsLoadError:
             pass
         # set default values
         self.opts.setdefault(border_w=0.01, border_c='black',
@@ -835,13 +835,13 @@ def main():
 
     # #38: adding config file
     if 'XDG_CONFIG_HOME' in os.environ:
-        config_dir = os.environ['XDG_CONFIG_HOME']
+        options_dir = os.environ['XDG_CONFIG_HOME']
     else:
-        config_dir = os.path.join(os.path.expanduser('~'), '.config')
-    config_fn = os.path.join(config_dir, 'photocollage', 'config.yml')
-    cfg = YamlConfig(cfg_fn=config_fn)
+        options_dir = os.path.join(os.path.expanduser('~'), '.config')
+    options_fn = os.path.join(options_dir, 'photocollage', 'options.yml')
+    options_manager = YamlOptionsManager(opts_fn=options_fn)
 
-    win = PhotoCollageWindow(config=cfg)
+    win = PhotoCollageWindow(options_manager=options_manager)
     win.connect("delete-event", Gtk.main_quit)
     win.show_all()
 

--- a/photocollage/gtkgui.py
+++ b/photocollage/gtkgui.py
@@ -468,6 +468,7 @@ class PhotoCollageWindow(Gtk.Window):
     def on_destroy(self, widget=None, *args):
         """Handles window closure properly"""
         self.opts.store()
+        Gtk.main_quit()
 
 
 class ImagePreviewArea(Gtk.DrawingArea):
@@ -846,9 +847,8 @@ def main():
     options_fn = os.path.join(options_dir, 'photocollage', 'options.yml')
     options_manager = YamlOptionsManager(opts_fn=options_fn)
     logging.debug(_("Config filename: '%s'") % options_fn)
-
     win = PhotoCollageWindow(options_manager=options_manager)
-    win.connect("delete-event", Gtk.main_quit)
+    win.connect("delete-event", win.on_destroy)
     win.show_all()
 
     # If arguments are given, treat them as input images

--- a/photocollage/gtkgui.py
+++ b/photocollage/gtkgui.py
@@ -18,6 +18,7 @@
 import copy
 import gettext
 from io import BytesIO
+import logging
 import math
 import os.path
 import random
@@ -28,6 +29,8 @@ import gi
 gi.require_version('Gtk', '3.0')  # noqa
 from gi.repository import Gtk, Gdk, GObject, GdkPixbuf
 from six.moves import urllib  # Python 2 backward compatibility
+
+logging.basicConfig(level=logging.DEBUG)
 
 from photocollage import APP_NAME, artwork, collage, render
 from photocollage.render import PIL_SUPPORTED_EXTS as EXTS
@@ -160,9 +163,9 @@ class PhotoCollageWindow(Gtk.Window):
     def __init__(self, options_manager):
         """
 
-        :param options_manager: dict-like storage for configuration data. Shall also
-            accept function `store`, that takes care of data persistence at
-            exit.
+        :param options_manager: dict-like storage for configuration data.
+            Shall also accept function `store`, that takes care of data
+            persistence at exit.
 
         """
         super(PhotoCollageWindow, self).__init__(title=_("PhotoCollage"))
@@ -185,7 +188,8 @@ class PhotoCollageWindow(Gtk.Window):
     def make_window(self):
         self.set_border_width(10)
 
-        box_window = Gtk.Box(spacing=10, orientation=Gtk.Orientation.VERTICAL)
+        box_window = Gtk.Box(spacing=10,
+                             orientation=Gtk.Orientation.VERTICAL)
         self.add(box_window)
 
         # -----------------------
@@ -320,8 +324,8 @@ class PhotoCollageWindow(Gtk.Window):
     def render_preview(self):
         collage = self.history[self.history_index]
 
-        # If the desired ratio changed in the meantime (e.g. from landscape to
-        # portrait), it needs to be re-updated
+        # If the desired ratio changed in the meantime (e.g. from landscape
+        # to portrait), it needs to be re-updated
         collage.page.target_ratio = 1.0 * self.opts.out_h / self.opts.out_w
         collage.page.adjust_cols_heights()
 
@@ -841,6 +845,7 @@ def main():
         options_dir = os.path.join(os.path.expanduser('~'), '.config')
     options_fn = os.path.join(options_dir, 'photocollage', 'options.yml')
     options_manager = YamlOptionsManager(opts_fn=options_fn)
+    logging.debug(_("Config filename: '%s'") % options_fn)
 
     win = PhotoCollageWindow(options_manager=options_manager)
     win.connect("delete-event", Gtk.main_quit)

--- a/photocollage/gtkgui.py
+++ b/photocollage/gtkgui.py
@@ -30,8 +30,6 @@ gi.require_version('Gtk', '3.0')  # noqa
 from gi.repository import Gtk, Gdk, GObject, GdkPixbuf
 from six.moves import urllib  # Python 2 backward compatibility
 
-logging.basicConfig(level=logging.DEBUG)
-
 from photocollage import APP_NAME, artwork, collage, render
 from photocollage.render import PIL_SUPPORTED_EXTS as EXTS
 from photocollage.config import YamlOptionsManager, OptionsLoadError
@@ -42,6 +40,8 @@ _n = gettext.ngettext
 # xgettext --keyword=_n:1,2 -o po/photocollage.pot $(find . -name '*.py')
 # cp po/photocollage.pot po/fr.po
 # msgfmt -o po/fr.mo po/fr.po
+
+DEFAULT_OPTS = dict(border_w=0.01, border_c='black', out_w=800, out_h=600)
 
 
 def pil_image_to_cairo_surface(src):
@@ -179,9 +179,7 @@ class PhotoCollageWindow(Gtk.Window):
         except OptionsLoadError:
             pass
         # set default values
-        # TODO: put this in a default location, or in a default option file
-        self.opts.setdefault(border_w=0.01, border_c='black',
-                             out_w=800, out_h=600)
+        self.opts.setdefault(**DEFAULT_OPTS)
 
         self.make_window()
 
@@ -836,6 +834,9 @@ class PreviewFileChooserDialog(Gtk.FileChooserDialog):
 
 
 def main():
+    # set level for logging
+    logging.basicConfig(level=logging.INFO)
+
     # Enable threading. Without that, threads hang!
     GObject.threads_init()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017 Joël Bourgault
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import os
+import unittest
+
+from photocollage.config import OptionsManager, YamlOptionsManager
+
+
+class TestOptionsManager(unittest.TestCase):
+    def setUp(self):
+        self.opts = OptionsManager()
+
+    def test_set_option(self):
+        self.opts.a = 1
+        self.assertEqual(self.opts._data, {'a': 1})
+
+    def test_set_second_option(self):
+        self.opts.a = 1
+        self.opts.b = 2
+        self.assertEqual(self.opts._data, {'a': 1, 'b': 2})
+
+    def test_setdefault(self):
+        self.opts.a = 1
+        self.opts.setdefault(a=0, b=2)
+        self.assertEqual(self.opts._data, {'a': 1, 'b': 2})
+
+    def test_update(self):
+        self.opts.a = 1
+        self.opts.update(a=0, b=2)
+        self.assertEqual(self.opts._data, {'a': 0, 'b': 2})
+
+
+class TestYamlOptionsManager(unittest.TestCase):
+    def setUp(self):
+        self.opts_fn = "opts.yml"
+        self.yaml_content = "config: {last_visited_dir: /home/adrien/photos}\n"
+        self.opts_content = {'last_visited_dir': '/home/adrien/photos'}
+
+        if os.path.exists(self.opts_fn):
+            os.remove(self.opts_fn)
+        self.opts = YamlOptionsManager(self.opts_fn)
+
+    def test_store(self):
+        self.opts.config = self.opts_content
+        self.opts.store()
+        with open(self.opts_fn) as fh:
+            opts_file_content = fh.read()
+        self.assertEqual(opts_file_content, self.yaml_content)
+
+    def test_read(self):
+        with open(self.opts_fn, 'w') as fh:
+            fh.write(self.yaml_content)
+        self.opts.load()
+        self.assertEqual(self.opts.config, self.opts_content)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is the first commit to implement #38: addition of an `options.yml` file, that makes parameters persistent on user filesystem.

User can modify the file then restart PhotoCollage; or user can modify the parameters through the settings dialog, then at exit, PhotoCollage will update the settings file.

