### PR TITLE
Fix new flake8 errors

### DIFF
--- a/photocollage/gtkgui.py
+++ b/photocollage/gtkgui.py
@@ -25,8 +25,8 @@ import sys
 
 import cairo
 import gi
-gi.require_version('Gtk', '3.0')  # noqa
-from gi.repository import Gtk, Gdk, GObject, GdkPixbuf
+gi.require_version('Gtk', '3.0')  # noqa: E402
+from gi.repository import Gtk, Gdk, GObject, GdkPixbuf  # noqa: I202
 from six.moves import urllib  # Python 2 backward compatibility
 
 from photocollage import APP_NAME, artwork, collage, render

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
 import-order-style = pep8
+application-import-names = photocollage


### PR DESCRIPTION
### style: Don't fail on gi.repository imports

It seems that flake8 is changing fast these days: it now detects new
false positives, cause by the weird way of `gi.repository` to set
imports versions (`gi.require_version()` has to be called between
imports).

This commit fixes that by disabling these specific rules on problematic
import lines.

---

### style: Fix new I202 errors from flake8

Explicitly tell `flake8-import-order` the current module name
(`photocollage`) so that it can make the difference between it and
third-party modules.
