### PR TITLE
Add support for newer Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 python:
   - 3.4
   - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
+  - 3.9-dev
   - nightly
 install:
   - pip install flake8 flake8-import-order

--- a/photocollage/gtkgui.py
+++ b/photocollage/gtkgui.py
@@ -25,12 +25,13 @@ import sys
 
 import cairo
 import gi
-gi.require_version('Gtk', '3.0')  # noqa: E402
-from gi.repository import Gtk, Gdk, GObject, GdkPixbuf  # noqa: I202
 from six.moves import urllib  # Python 2 backward compatibility
 
 from photocollage import APP_NAME, artwork, collage, render
 from photocollage.render import PIL_SUPPORTED_EXTS as EXTS
+
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gdk, GObject, GdkPixbuf  # noqa: E402, I100
 
 
 gettext.textdomain(APP_NAME)

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,10 @@ distutils.core.setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Multimedia :: Graphics",
     ],
 


### PR DESCRIPTION
~And add `python_requires` to help pip install the right library version for the user's Python.~ Edit: left this out, looks like `distutils` doesn't support it. (There's an effort underway to remove distutils from the stdlib and replace it with setuptools, so I'd suggest at some point switching distutils to setuptools here too.)