### PR TITLE
gtkgui: Import urlib.parse instead of urllib

### DIFF
--- a/photocollage/gtkgui.py
+++ b/photocollage/gtkgui.py
@@ -21,7 +21,7 @@ import math
 import os.path
 import random
 import sys
-import urllib
+import urllib.parse
 
 import cairo
 import gi


### PR DESCRIPTION
Because:

    >>> import urllib
    >>> urllib.parse.unquote('file://test')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    AttributeError: module 'urllib' has no attribute 'parse'
    >>> import urllib.parse
    >>> urllib.parse.unquote('file://test')
    'file://test'

Closes https://github.com/adrienverge/PhotoCollage/issues/109